### PR TITLE
Add Readme.md -> MDX dynamic generation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *
+!templates
 !server.js
 !package.json

--- a/package.json
+++ b/package.json
@@ -8,10 +8,13 @@
   "author": "Nathan Rajlich <n@n8.io>",
   "license": "MIT",
   "dependencies": {
+    "@mdx-js/runtime": "^0.15.0-2",
     "bytes": "^3.0.0",
     "lru-cache": "^4.1.3",
     "micro": "^9.3.2",
     "node-fetch": "^2.1.2",
-    "raw-body": "^2.3.3"
+    "raw-body": "^2.3.3",
+    "react": "^16.4.2",
+    "react-dom": "^16.4.2"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,12 +1,17 @@
 const bytes = require('bytes');
 const {parse} = require('url');
 const LRU = require('lru-cache');
+const {resolve} = require('path');
 const fetch = require('node-fetch');
 const toBuffer = require('raw-body');
+const {readFileSync} = require('fs');
 const {createElement} = require('react');
 const {default: MDX} = require('@mdx-js/runtime');
-const {renderToStaticMarkup, renderToStaticNodeStream} = require('react-dom/server');
+const {renderToStaticNodeStream} = require('react-dom/server');
 const {IMPORT_ORG = 'importpw', IMPORT_REPO = 'import'} = process.env;
+
+const indexTemplate = resolve(__dirname, 'templates', 'index.html');
+const [HTML_START, HTML_END] = readFileSync(indexTemplate, 'utf8').split('__CONTENT__');
 
 const toURL = ({repo, org, ref, file}) => (
   `https://raw.githubusercontent.com/${org}/${repo}/${ref}/${file}`
@@ -62,11 +67,16 @@ module.exports = async (req, res) => {
     res.setHeader('Content-Type', 'text/plain');
     return `Expected up to 2 slashes in the URL, but got ${numParts}\n`;
   }
+
   if (isHTML) {
     // TODO: Support case-insensitive filename, and non-markdown
     file = 'Readme.md';
   }
-  if (!file) file = `${repo}.sh`;
+
+  if (!file) {
+    file = `${repo}.sh`;
+  }
+
   const params = {repo, org, ref, file};
   const id = JSON.stringify(params);
   let cached = cache.get(id);
@@ -96,11 +106,17 @@ module.exports = async (req, res) => {
   }
 
   if (isHTML) {
+    // Render the readme as MDX
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
     const el = createElement(MDX, {
       children: cached.body.toString('utf8')
     });
-    renderToStaticNodeStream(el).pipe(res);
+    const reactStream = renderToStaticNodeStream(el);
+    res.write(HTML_START);
+    reactStream.pipe(res, {end: false});
+    reactStream.on('end', () => {
+      res.end(HTML_END);
+    });
   } else {
     res.statusCode = cached.status;
     for (const name of Object.keys(cached.headers)) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link href="https://sf.n8.io/?weight=normal,bold&style=normal,italic" rel="stylesheet">
+    <link href="https://styles.import.pw" rel="stylesheet">
+  </head>
+  <body>
+    __CONTENT__
+  </body>
+</html>


### PR DESCRIPTION
When an import module is requested from the browser,
MDX is used to render the Markdown readme file to HTML.

This is very basic still. Needs cool styling.