### PR TITLE
Use the GitHub API to resolve the ref and select better default entrypoint files

### DIFF
--- a/now.json
+++ b/now.json
@@ -4,5 +4,8 @@
   "alias": "gh.import.pw",
   "features": {
     "cloud": "v2"
+  },
+  "env": {
+    "GITHUB_TOKEN": "@importpw-github-token"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@mdx-js/runtime": "^0.15.0-2",
     "bytes": "^3.0.0",
+    "github-api": "^3.0.0",
     "lru-cache": "^4.1.3",
     "micro": "^9.3.2",
     "node-fetch": "^2.1.2",


### PR DESCRIPTION
So now the ref is properly resolved in the `Content-Location` header,
and default entry points like the filename matching the repo name now
work as expected.

This makes https://import.pw/kward/shunit2 work.