### PR TITLE
Fix relative links

### DIFF
--- a/components/curry.js
+++ b/components/curry.js
@@ -1,0 +1,5 @@
+export default function Curry(C, props) {
+  return (ownProps) => {
+    return <C {...props} {...ownProps}>{ownProps.children}</C>;
+  };
+}

--- a/components/link.js
+++ b/components/link.js
@@ -1,8 +1,15 @@
+import { join } from 'path';
 import Link from 'next/link';
 
 export default function MarkdownLink (props) {
   const ownProps = Object.assign({}, props);
   let { href } = ownProps;
   delete ownProps.href;
-  return <Link href={href}><a {...ownProps}>{props.children}</a></Link>;
+
+  const isRelative = /^\.\.?\//.test(href);
+  if (isRelative) {
+    href = '/' + join(props.org, props.repo, href);
+  }
+
+  return <Link href={href}><a>{props.children}</a></Link>;
 }

--- a/pages/layout.js
+++ b/pages/layout.js
@@ -4,17 +4,13 @@ import MarkdownCode from '../components/code';
 import MarkdownImage from '../components/image';
 import MarkdownLink from '../components/link';
 
+import curry from '../components/curry';
+
 // Icons
 import Arrow from '../components/icons/arrow';
 import GitHub from '../components/icons/github';
 import Logotype from '../components/icons/import';
 import EvilRabbit from '../components/icons/evilrabbit';
-
-const renderers = {
-  code: MarkdownCode,
-  image: MarkdownImage,
-  link: MarkdownLink
-};
 
 export default class extends React.Component {
   static async getInitialProps({ req, query }) {
@@ -49,6 +45,12 @@ export default class extends React.Component {
       title += `@${commitish}`;
     }
     title = title.trim();
+
+    const renderers = {
+      code: MarkdownCode,
+      image: MarkdownImage,
+      link: curry(MarkdownLink, this.props)
+    };
 
     const markdown = <Markdown
       className="markdown"


### PR DESCRIPTION
By introducing a `Curry` component, we can pass in the parent
props to the `MarkdownLink` component so that it has the necessary
context to know about which org / repo is being rendered. And
with that information we can fix relative links to match the URL
structure of `import.pw-server`.